### PR TITLE
Configuration changes and additions.

### DIFF
--- a/drivers/sensors/maxtouch.h
+++ b/drivers/sensors/maxtouch.h
@@ -125,6 +125,17 @@ typedef struct PACKED {
     unsigned char cfg;
 } mxt_gen_acquisitionconfig_t8;
 
+static const unsigned char T42_CTRL_ENABLE = 0x01;
+static const unsigned char T42_CTRL_SHAPEEN = 0x04;
+static const unsigned char T42_CTRL_DISLOBJ = 0x08;
+static const unsigned char T42_CTRL_DISTLOCK = 0x10;
+static const unsigned char T42_CTRL_SUPDISTEN = 0x20;
+static const unsigned char T42_CTRL_EDGESUP = 0x40;
+
+static const unsigned char T42_CFG_RELAXCLOSEUP = 0x01;
+static const unsigned char T42_CFG_RELAXDIAGSUP = 0x02;
+static const unsigned char T42_CFG_SUPTCHRPTEN = 0x04;
+
 typedef struct PACKED {
     unsigned char ctrl;
     unsigned char reserved;
@@ -142,6 +153,9 @@ typedef struct PACKED {
     unsigned char edgesupstrength;
 } mxt_proci_touchsupression_t42;
 
+static const unsigned char T46_CFG_SYNCLOSSMODE = 0x02;
+static const unsigned char T46_CFG_DELTASHIFT = 0x04;
+
 typedef struct PACKED {
     unsigned char reserved[2];
     unsigned char idlesyncsperx;
@@ -157,6 +171,7 @@ typedef struct PACKED {
     unsigned char cfg;
 } mxt_spt_cteconfig_t46;
 
+static const unsigned char T47_CFG_SUPSTY = 0x20;
 
 typedef struct PACKED {
     unsigned char ctrl;
@@ -201,6 +216,8 @@ typedef struct PACKED {
     unsigned char satbdxxhi;
     unsigned char movhistcfg;
 } mxt_proci_stylus_t47;
+
+
 
 typedef struct PACKED {
     unsigned char ctrl;


### PR DESCRIPTION
I went through the protocol guide and found a bunch of things to tune. Here's a summary of the changes, hopefully all for the better:

T7: 
- Let the analog acquisition free-run to maximize speed. No delays between samples at all FOR MAXIMUM PERFORRRRRMANCE.
T100:
- SCANEN - enable close scanning to help detect multiple fingers
- Reduced MXT_CPI to 400; avoids exceeding cfg.xsize and cfg.ysize specs in T100 object (limited to 65,534 per page 55 of the MaxTouch protocol guide).
T42:
- Activated the T42 touch suppression object and picked some sane-seeming defaults for the various settings.
T46:
- Activate the inrush current resistors, set to 1k.
T47:
- Tune CONTMAX down a little, so that fingers are less likely to be mistaken as stylus touches.
- Adjusted some of the other parameters with testing.